### PR TITLE
Setup dependencies: Halide and gflags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 # Build folders
 /build/
+/build_release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.13.0)
 project(pp VERSION 0.1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include(ExternalProject)
 include(GNUInstallDirs)

--- a/ParallelProject.code-workspace
+++ b/ParallelProject.code-workspace
@@ -29,6 +29,9 @@
 			"editor.defaultFormatter": "vscode.typescript-language-features"
 		},
 		"cmake.sourceDirectory": "${workspaceFolder}",
+		"files.associations": {
+			"ostream": "cpp"
+		},
 	},
 	"extensions": {
 		"recommendations": [

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -10,3 +10,8 @@ list(APPEND pp_LINKER_LIBS PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 include("cmake/External/gflags.cmake")
 list(APPEND pp_INCLUDE_DIRS PUBLIC ${GFLAGS_INCLUDE_DIRS})
 list(APPEND pp_LINKER_LIBS PUBLIC ${GFLAGS_LIBRARIES})
+
+# ---[ Halide
+find_package(LLVM REQUIRED CONFIG PATHS /usr/local/Cellar/)
+find_package(Halide REQUIRED)
+list(APPEND pp_LINKER_LIBS PRIVATE Halide::Halide)

--- a/cmake/External/gflags.cmake
+++ b/cmake/External/gflags.cmake
@@ -23,10 +23,10 @@ if (NOT __GFLAGS_INCLUDED) # guard against multiple includes
     set(GFLAGS_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${GFLAGS_EXTRA_COMPILER_FLAGS})
     set(GFLAGS_C_FLAGS ${CMAKE_C_FLAGS} ${GFLAGS_EXTRA_COMPILER_FLAGS})
 
-    ExternalProject_Add(gflags
+    ExternalProject_Add(gflags-static
       PREFIX ${gflags_PREFIX}
       GIT_REPOSITORY "https://github.com/gflags/gflags.git"
-      GIT_TAG "v2.1.2"
+      GIT_TAG "v2.2.2"
       UPDATE_COMMAND ""
       INSTALL_DIR ${gflags_INSTALL}
       CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -35,7 +35,6 @@ if (NOT __GFLAGS_INCLUDED) # guard against multiple includes
                  -DBUILD_STATIC_LIBS=ON
                  -DBUILD_PACKAGING=OFF
                  -DBUILD_TESTING=OFF
-                 -DBUILD_CONFIG_TESTS=OFF
                  -DBUILD_NC_TESTS=OFF
                  -DINSTALL_HEADERS=ON
                  -DCMAKE_C_FLAGS=${GFLAGS_C_FLAGS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(pp main.cpp)
+add_executable(pp main.cpp flags.cpp)
 target_link_libraries(pp ${pp_LINKER_LIBS})

--- a/src/flags.cpp
+++ b/src/flags.cpp
@@ -1,0 +1,5 @@
+#include "flags.h"
+#include <iostream>
+
+DEFINE_bool(h, false, "Show help message");
+DEFINE_double(brightness, 0.0, "Set brightness");

--- a/src/flags.h
+++ b/src/flags.h
@@ -1,0 +1,41 @@
+// Thin wrapper for gflags because of its stupid help message handling
+#pragma once
+
+#include <gflags/gflags.h>
+#include <iostream>
+#include <unordered_set>
+#include <vector>
+
+DECLARE_bool(help);
+DECLARE_bool(h);
+DECLARE_double(brightness);
+
+class Flags {
+  const std::unordered_set<std::string> helpFlags{"help", "brightness"};
+
+  void showHelpMessage(const char *argv0) {
+    std::cout << argv0 << ": " << gflags::ProgramUsage() << std::endl;
+    std::vector<gflags::CommandLineFlagInfo> flags;
+    gflags::GetAllFlags(&flags);
+    for (const gflags::CommandLineFlagInfo &flag : flags) {
+      if (helpFlags.find(flag.name) != helpFlags.cend()) {
+        std::cout << gflags::DescribeOneFlag(flag);
+      }
+    }
+    std::cout << std::flush;
+  }
+
+public:
+  Flags(int argc, char **argv) {
+    gflags::SetUsageMessage("Usage:");
+    gflags::SetVersionString("0.0.1");
+    gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
+    if (FLAGS_help || FLAGS_h) {
+      FLAGS_help = false;
+      showHelpMessage(argv[0]);
+    }
+    gflags::HandleCommandLineHelpFlags();
+  }
+
+  ~Flags() { gflags::ShutDownCommandLineFlags(); }
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,32 @@
 #include "flags.h"
+#include <Halide.h>
+#include <cstdio>
 #include <iostream>
-#include <string>
-#include <vector>
 
-int main(int argc, char **argv) { Flags f(argc, argv); }
+int main(int argc, char **argv) {
+  Flags f(argc, argv);
+
+  Halide::Func gradient;
+  Halide::Var x, y;
+
+  Halide::Expr e = x + y;
+
+  gradient(x, y) = e;
+
+  Halide::Buffer<int32_t> output = gradient.realize({800, 600});
+
+  for (int j = 0; j < output.height(); j++) {
+    for (int i = 0; i < output.width(); i++) {
+      // We can access a pixel of an Buffer object using similar
+      // syntax to defining and using functions.
+      if (output(i, j) != i + j) {
+        printf("Something went wrong!\n"
+               "Pixel %d, %d was supposed to be %d, but instead it's %d\n",
+               i, j, i + j, output(i, j));
+        return -1;
+      }
+    }
+  }
+
+  printf("All good\n");
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
+#include "flags.h"
 #include <iostream>
+#include <string>
+#include <vector>
 
-int main(int, char**) {
-    std::cout << "Hello, world!\n";
-}
+int main(int argc, char **argv) { Flags f(argc, argv); }


### PR DESCRIPTION
1. gflags is added as an external project in CMake that will be built with the project
2. Halide is very tricky to build (it requires LLVM) so it is imported as binaries. 